### PR TITLE
Adding GitHub Actions test

### DIFF
--- a/.github/actions/prepare-test/action.yml
+++ b/.github/actions/prepare-test/action.yml
@@ -1,0 +1,87 @@
+name: 'Prepare test'
+description: 'Prepare environment before test'
+inputs:
+  db_type:
+    description: 'mysql, postgres, sqlite'
+    required: true
+    default: 'sqlite'
+  additional_packages:
+    description: 'Install additional packages'
+    required: false
+    default: false
+  system_test:
+    description: 'Prepare system test environment'
+    required: false
+    default: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install apt packages
+      run: |
+        apt-get update
+        apt-get install -y --no-install-recommends gsfonts
+        if [ ${{ inputs.additional_packages }} = true ]; then
+          apt-get install -y --no-install-recommends \
+            bzr git mercurial subversion \
+            gsfonts ghostscript imagemagick
+          sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
+        fi
+        if [ ${{ inputs.db_type }} = "mysql" ]; then
+          apt-get install -y --no-install-recommends default-mysql-client-core
+        fi
+        if [ ${{ inputs.db_type }} = "postgres" ]; then
+          apt-get install -y --no-install-recommends postgresql-client
+        fi
+        # For system test
+        if [ ${{ inputs.system_test }} = true ]; then
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+          sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+          apt-get update
+          apt-get install -y google-chrome-stable
+        fi
+      shell: bash
+    - name: Prepare config/database.yml
+      run: |
+        if [ ${{ inputs.db_type }} = "mysql" ]; then
+          cat <<EOF > config/database.yml
+            test:
+              adapter: mysql2
+              database: redmine
+              host: mysql
+              username: root
+              password: password
+              encoding: utf8mb4
+        EOF
+        fi
+        if [ ${{ inputs.db_type }} = "postgres" ]; then
+          cat <<EOF > config/database.yml
+            test:
+              adapter: postgresql
+              database: redmine
+              host: postgres
+              username: postgres
+              password: postgres
+              encoding: utf8
+        EOF
+        fi
+        if [ ${{ inputs.db_type }} = "sqlite" ]; then
+          cat <<EOF > config/database.yml
+            test:
+              adapter: sqlite3
+              database: db/redmine.sqlite3
+        EOF
+        fi
+      shell: bash
+    - name: Install gem
+      run: |
+        if [ ${{ inputs.additional_packages }} = true ]; then
+          bundle config set --local path 'vendor/bundle' without 'development'
+        else
+          bundle config set --local path 'vendor/bundle' without 'development minimagick'
+        fi
+        bundle install --jobs=4 --retry=3
+      shell: bash
+    - name: Prepare database
+      run: bundle exec rake db:create db:migrate
+      shell: bash

--- a/.github/workflows/matrix-test-4.2.yml
+++ b/.github/workflows/matrix-test-4.2.yml
@@ -1,0 +1,93 @@
+name: Matrix Test (4.2)
+
+on:
+  push:
+    branches:
+      - 4.2-stable
+  pull_request:
+    branches:
+      - '**4.2-stable'
+
+env:
+  RAILS_ENV: test
+  PARALLEL_WORKERS: 1
+
+jobs:
+  test-with-mysql:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.4', '2.5', '2.6', '2.7']
+        db_version: ['5.7']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    services:
+      mysql:
+        image: mysql:${{ matrix.db_version }}
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: mysql
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake test
+
+  test-with-postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.4', '2.5', '2.6', '2.7']
+        db_version: ['10']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    services:
+      postgres:
+        image: postgres:${{ matrix.db_version }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: postgres
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake test
+
+  test-with-sqlite:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.4', '2.5', '2.6', '2.7']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: sqlite
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake test

--- a/.github/workflows/matrix-test.yml
+++ b/.github/workflows/matrix-test.yml
@@ -1,0 +1,98 @@
+name: Matrix Test
+
+on:
+  push:
+    branches:
+      - master
+      - 5.0-stable
+  pull_request:
+    branches:
+      - '**master'
+      - '**5.0-stable'
+
+env:
+  RAILS_ENV: test
+  PARALLEL_WORKERS: 1
+
+jobs:
+  test-with-mysql:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.6', '2.7', '3.0', '3.1']
+        db_version: ['5.7']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    services:
+      mysql:
+        image: mysql:${{ matrix.db_version }}
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: mysql
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake zeitwerk:check
+          bundle exec rake test
+
+  test-with-postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.6', '2.7', '3.0', '3.1']
+        db_version: ['10']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    services:
+      postgres:
+        image: postgres:${{ matrix.db_version }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: postgres
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake zeitwerk:check
+          bundle exec rake test
+
+  test-with-sqlite:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.6', '2.7', '3.0', '3.1']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: sqlite
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake zeitwerk:check
+          bundle exec rake test

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,28 @@
+name: RuboCop
+
+on:
+  push:
+    branches:
+      - master
+      - 5.0-stable
+      - 4.2-stable
+  pull_request:
+    branches:
+      - '**master'
+      - '**5.0-stable'
+      - '**4.2-stable'
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:2.7-buster
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Install gem
+        run: |
+          bundle config set --local path 'vendor/bundle' without 'development postgres minimagick mysql2'
+          bundle install --jobs=4 --retry=3
+      - name: Run rubocop
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -1,0 +1,30 @@
+name: Stylelint
+
+on:
+  push:
+    branches:
+      - master
+      - 5.0-stable
+      - 4.2-stable
+    paths:
+      - 'public/stylesheets/**/*.css'
+  pull_request:
+    branches:
+      - '**master'
+      - '**5.0-stable'
+      - '**4.2-stable'
+    paths:
+      - 'public/stylesheets/**/*.css'
+
+jobs:
+  stylelint:
+    runs-on: ubuntu-20.04
+    container:
+      image: node:alpine
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Install npm
+        run: yarn install
+      - name: Run stylelint
+        run: yarn stylelint "public/stylesheets/**/*.css"

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -1,0 +1,56 @@
+name: System Test
+
+on:
+  push:
+    branches:
+      - master
+      - 5.0-stable
+      - 4.2-stable
+  pull_request:
+    branches:
+      - '**master'
+      - '**5.0-stable'
+      - '**4.2-stable'
+
+env:
+  RAILS_ENV: test
+  PARALLEL_WORKERS: 1
+
+jobs:
+  system-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.7']
+        db_version: ['5.7']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    services:
+      mysql:
+        image: mysql:${{ matrix.db_version }}
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: mysql
+          additional_packages: true
+          system_test: true
+      - name: Run system test
+        env:
+          GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
+        run: |
+          bundle exec rake test:system
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: failure-screenshots
+          path: tmp/screenshots/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+      - 5.0-stable
+      - 4.2-stable
+  pull_request:
+    branches:
+      - '**master'
+      - '**5.0-stable'
+      - '**4.2-stable'
+
+env:
+  RAILS_ENV: test
+  PARALLEL_WORKERS: 1
+
+jobs:
+  test-with-mysql:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.7']
+    runs-on: ubuntu-20.04
+    container:
+      image: ruby:${{ matrix.ruby_version }}-buster
+    steps:
+      - name: Checkout Redmine
+        uses: actions/checkout@v3
+      - name: Prepare test
+        uses: ./.github/actions/prepare-test
+        with:
+          db_type: sqlite
+          additional_packages: true
+      - name: Run tests
+        run: |
+          bundle exec rake zeitwerk:check
+          bundle exec rake test


### PR DESCRIPTION
Trying to add GitHub Actions which supports current Jenkins matrix test ([Redmine build status](https://www.redmine.org/builds/index.html)) and some more additional tests (rubocop, stylelint, system test) with referring the following existence CI sources.
* GitLab CI by Marius: https://gitlab.com/redmine-org/redmine/-/blob/feature/gitlab_integration/.gitlab-ci.yml
* GitHub Actions by Redmine Patch Meetup contributors: https://github.com/redmine-patch-meetup/redmine-dev-mirror/blob/develop/.github/workflows/test.yml

Currently, parallel mode (`PARALLEL_WORKERS >= 2`) fails in some test cases, so I set it to 1 in matrix test, but if the test is stable in parallel mode, matrix test time will be about 2 times faster.